### PR TITLE
add support for matching request address based on headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,16 @@ $ vault write auth/openstack/config \
     auth_url="${OS_AUTH_URL}" \
     tenant_name="${OS_TENANT_NAME}" \
     username="${OS_USERNAME}" \
-    password="${OS_PASSWORD}"
+    password="${OS_PASSWORD}" \
+    request_address_headers="X-Forwarded-For" \
+    request_address_headers="X-Real-Ip"
+```
+
+If you want to use the request headers you also have to tune the vault auth plugin:
+```
+$ vault write sys/auth/openstack/tune \
+    passthrough_request_headers="X-Forwarded-For" \
+    passthrough_request_headers="X-Real-Ip"
 ```
 
 Create a role to associate the OpenStack instance with the Vault policies. The following example creates a role named "dev" associated with the vault policy "prod" and "dev". This example role is identified by the vault-role key contained in Metadata of the OpenStack instance, and up to 3 times of authentication can be attempted in 120 seconds after instance is created.
@@ -83,7 +92,7 @@ This plugin gets the instance information from the OpenStack API and attestates 
 3. Get the role configuration based on the role name. If the role configuration does not exist, the authenticate fails.
 4. Validate the authentication period specified in the role with the creation time of the instance. If the deadline was exceeded, the authentication fails.
 5. Validate the limit of authentication attempt count specified in the role. If authentication exceeds the maximum number of attempts, the authentication fails.
-6. Validate the instance IP address with the remote IP address of `vault login`. If address mismatched, the authentication fails.
+6. Validate the instance IP address with the remote IP address of `vault login`. If address mismatched, the authentication fails. If configured also the IP addresses from the request headers are used for validation.
 7. Validate the status of the instance. If the instance is not active, the authentication fails.
 8. Validate the role name contained in the metadata of the instance with the key specified in the role configuration. If the key of metadata does not exist or role name is mismatched, the authentication fails.
 9. Validate the tenant ID of the instance with the role configuration. If the tenand ID is mismatched, the authentication fails. This validation is performed only if the tenant ID is specified in the role configuration.
@@ -113,4 +122,4 @@ $ task cover
 
 ## Should I Use This?
 
-This is an experimental plugin. We don't reccomend to use this in your production.
+This is an experimental plugin. We don't recommend to use this in your production.

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -7,21 +7,22 @@ import (
 )
 
 type Config struct {
-	AuthURL           string `json:"auth_url" structs:"auth_url" mapstructure:"auth_url"`
-	Token             string `json:"token" structs:"token" mapstructure:"token"`
-	UserID            string `json:"user_id" structs:"user_id" mapstructure:"user_id"`
-	Username          string `json:"username" structs:"username" mapstructure:"username"`
-	Password          string `json:"password" structs:"password" mapstructure:"password"`
-	ProjectID         string `json:"project_id" structs:"project_id" mapstructure:"project_id"`
-	ProjectName       string `json:"project_name" structs:"project_name" mapstructure:"project_name"`
-	TenantID          string `json:"tenant_id" structs:"tenant_id" mapstructure:"tenant_id"`
-	TenantName        string `json:"tenant_name" structs:"tenant_name" mapstructure:"tenant_name"`
-	UserDomainID      string `json:"user_domain_id" structs:"user_domain_id" mapstructure:"user_domain_id"`
-	UserDomainName    string `json:"user_domain_name" structs:"user_domain_name" mapstructure:"user_domain_name"`
-	ProjectDomainID   string `json:"project_domain_id" structs:"project_domain_id" mapstructure:"project_domain_id"`
-	ProjectDomainName string `json:"project_domain_name" structs:"project_domain_name" mapstructure:"project_domain_name"`
-	DomainID          string `json:"domain_id" structs:"domain_id" mapstructure:"domain_id"`
-	DomainName        string `json:"domain_name" structs:"domain_name" mapstructure:"domain_name"`
+	AuthURL               string   `json:"auth_url" structs:"auth_url" mapstructure:"auth_url"`
+	Token                 string   `json:"token" structs:"token" mapstructure:"token"`
+	UserID                string   `json:"user_id" structs:"user_id" mapstructure:"user_id"`
+	Username              string   `json:"username" structs:"username" mapstructure:"username"`
+	Password              string   `json:"password" structs:"password" mapstructure:"password"`
+	ProjectID             string   `json:"project_id" structs:"project_id" mapstructure:"project_id"`
+	ProjectName           string   `json:"project_name" structs:"project_name" mapstructure:"project_name"`
+	TenantID              string   `json:"tenant_id" structs:"tenant_id" mapstructure:"tenant_id"`
+	TenantName            string   `json:"tenant_name" structs:"tenant_name" mapstructure:"tenant_name"`
+	UserDomainID          string   `json:"user_domain_id" structs:"user_domain_id" mapstructure:"user_domain_id"`
+	UserDomainName        string   `json:"user_domain_name" structs:"user_domain_name" mapstructure:"user_domain_name"`
+	ProjectDomainID       string   `json:"project_domain_id" structs:"project_domain_id" mapstructure:"project_domain_id"`
+	ProjectDomainName     string   `json:"project_domain_name" structs:"project_domain_name" mapstructure:"project_domain_name"`
+	DomainID              string   `json:"domain_id" structs:"domain_id" mapstructure:"domain_id"`
+	DomainName            string   `json:"domain_name" structs:"domain_name" mapstructure:"domain_name"`
+	RequestAddressHeaders []string `json:"request_address_headers" structs:"request_address_headers" mapstructure:"request_address_headers"`
 }
 
 func readConfig(ctx context.Context, s logical.Storage) (*Config, error) {

--- a/plugin/path_config.go
+++ b/plugin/path_config.go
@@ -75,6 +75,10 @@ var configFields map[string]*framework.FieldSchema = map[string]*framework.Field
 		Type:        framework.TypeString,
 		Description: "Name of a domain which can be used to identify the source domain of either a user or a project.",
 	},
+	"request_address_headers": {
+		Type:        framework.TypeStringSlice,
+		Description: "List of header names which can be used to identify the address of the request in addition to the real remote address.",
+	},
 }
 
 func NewPathConfig(b *OpenStackAuthBackend) []*framework.Path {
@@ -105,19 +109,20 @@ func (b *OpenStackAuthBackend) readConfigHandler(ctx context.Context, req *logic
 
 	res := &logical.Response{
 		Data: map[string]interface{}{
-			"auth_url":            config.AuthURL,
-			"user_id":             config.UserID,
-			"username":            config.Username,
-			"project_id":          config.ProjectID,
-			"project_name":        config.ProjectName,
-			"tenant_id":           config.TenantID,
-			"tenant_name":         config.TenantName,
-			"user_domain_id":      config.UserDomainID,
-			"user_domain_name":    config.UserDomainName,
-			"project_domain_id":   config.ProjectDomainID,
-			"project_domain_name": config.ProjectDomainName,
-			"domain_id":           config.DomainID,
-			"domain_name":         config.DomainName,
+			"auth_url":                config.AuthURL,
+			"user_id":                 config.UserID,
+			"username":                config.Username,
+			"project_id":              config.ProjectID,
+			"project_name":            config.ProjectName,
+			"tenant_id":               config.TenantID,
+			"tenant_name":             config.TenantName,
+			"user_domain_id":          config.UserDomainID,
+			"user_domain_name":        config.UserDomainName,
+			"project_domain_id":       config.ProjectDomainID,
+			"project_domain_name":     config.ProjectDomainName,
+			"domain_id":               config.DomainID,
+			"domain_name":             config.DomainName,
+			"request_address_headers": config.RequestAddressHeaders,
 		},
 	}
 
@@ -210,6 +215,11 @@ func (b *OpenStackAuthBackend) updateConfigHandler(ctx context.Context, req *log
 	val, ok = data.GetOk("domain_name")
 	if ok {
 		config.DomainName = val.(string)
+	}
+
+	val, ok = data.GetOk("request_address_headers")
+	if ok {
+		config.RequestAddressHeaders = val.([]string)
 	}
 
 	entry, err := logical.StorageEntryJSON("config", config)


### PR DESCRIPTION
If you deploy vault behind a reverse proxy like traefik the request address is not accurate and therefore the instance address will never match. This PR adds the option to also use request headers for matching the address. Please note that you have to configure the auth plugin to use the headers and also tune vault to pass them trough in the first place.